### PR TITLE
Make sure we check for php://input in case a POST body is in there

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -22,12 +22,18 @@
 		return $m[1].StrToUpper($m[2]);
 	}
 
+    # check for input based body as well
+    # as mentioned here, http://www.php.net/manual/en/wrappers.php.php
+    $post_body = file_get_contents("php://input");
+    if (strlen($post_body) > 0) {
+        $_POST = $post_body;
+    }
+
 	$req = array(
 		'headers'	=> $headers,
 		'get'		=> $_GET,
 		'post'		=> $_POST,
 	);
-
 
 	#
 	# log to a file (this is temporary)


### PR DESCRIPTION
It seem like the `$_POST` variable is just not set when performing POST operations that contain a JSON body. I apologize if any of this is silly, or I'm doing it wrong, but PHP is not my main language, and this seems to be a pretty common thing from what I can tell from StackOverflow ([example](http://stackoverflow.com/questions/1282909/php-post-array-empty-upon-form-submission)]

This seems like the right place to put this code as I think the `php://input` can only be called once. Please feel free to advise. 

I stumbled upon this when writing an integration for the new TestFlight webhooks beta.
