### PR TITLE
fix papertrail plugin for single event (var typo)

### DIFF
--- a/plugins/papertrail/plugin.php
+++ b/plugins/papertrail/plugin.php
@@ -108,7 +108,7 @@
 				return $this->sendMessage($text);
 			}
 
-			if ($commit_count) {
+			if ($num_events) {
 				$text = $this->searchLink($search) . $this->renderEvent($events[0]);
 				return $this->sendMessage($text);
 			}


### PR DESCRIPTION
this fixes the papertrail plugin for when there's a single event in the payload
